### PR TITLE
Add support for sending the request id with a response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,18 @@ If you use Symfony's [MonologBundle] you can add the request id to your monolog 
 ```
 
 [MonologBundle]: https://github.com/symfony/MonologBundle
+
+## Adding the request id to responses
+If you need to send the request id back with the response you can enable the response header:
+
+```php5
+$generator = new UuidRequestIdGenerator(1337);
+$stack = new RequestId($kernel, $generator);
+$stack->enableResponseHeader();
+```
+
+It is also possible to change response header's name:
+
+```php5
+$stack->enableResponseHeader('My-Custom-Request-Id');
+```

--- a/src/Qandidate/Stack/RequestId.php
+++ b/src/Qandidate/Stack/RequestId.php
@@ -23,6 +23,7 @@ class RequestId implements HttpKernelInterface
     private $app;
     private $generator;
     private $header;
+    private $responseHeader;
 
     public function __construct(HttpKernelInterface $app, RequestIdGenerator $generator, $header = 'X-Request-Id')
     {
@@ -40,6 +41,17 @@ class RequestId implements HttpKernelInterface
             $request->headers->set($this->header, $this->generator->generate());
         }
 
-        return $this->app->handle($request, $type, $catch);
+        $response = $this->app->handle($request, $type, $catch);
+
+        if (null !== $this->responseHeader) {
+            $response->headers->set($this->responseHeader, $request->headers->get($this->header));
+        }
+
+        return $response;
+    }
+
+    public function enableResponseHeader($header = 'X-Request-Id')
+    {
+        $this->responseHeader = $header;
     }
 }

--- a/test/Qandidate/Stack/RequestIdTest.php
+++ b/test/Qandidate/Stack/RequestIdTest.php
@@ -67,6 +67,52 @@ class RequestIdTest extends TestCase
         $this->assertEquals('foo', $this->app->getLastHeaderValue());
     }
 
+    /**
+     * @test
+     */
+    public function it_sets_the_request_id_in_the_response_header_if_enabled()
+    {
+        $this->stackedApp->enableResponseHeader();
+
+        $this->requestIdGenerator->expects($this->any())
+            ->method('generate')
+            ->will($this->returnValue('yolo'));
+
+        $response = $this->stackedApp->handle($this->createRequest());
+
+        $this->assertSame('yolo', $response->headers->get($this->header));
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_the_request_id_in_a_custom_response_header_if_given()
+    {
+        $this->stackedApp->enableResponseHeader('Request-Id');
+
+        $this->requestIdGenerator->expects($this->any())
+            ->method('generate')
+            ->will($this->returnValue('yolo'));
+
+        $response = $this->stackedApp->handle($this->createRequest());
+
+        $this->assertSame('yolo', $response->headers->get('Request-Id'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_set_the_request_id_in_the_response_header_by_default()
+    {
+        $this->requestIdGenerator->expects($this->any())
+            ->method('generate')
+            ->will($this->returnValue('yolo'));
+
+        $response = $this->stackedApp->handle($this->createRequest());
+
+        $this->assertFalse($response->headers->has($this->header), 'The request id is not added to the response by default');
+    }
+
     private function createRequest($requestId = null)
     {
         $request  = new Request();


### PR DESCRIPTION
I've got a requirement for this feature. I could write a new middleware, but I think it makes sense to support it here.

The feature is made optional.
