### PR TITLE
Update dependency to maintained uuid project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "symfony/http-kernel": "~2.1",
         "symfony/http-foundation": "~2.1",
-        "rhumsaa/uuid": "~2.0"
+        "ramsey/uuid": "~2.0"
     },
     "authors": [
         {


### PR DESCRIPTION
The rhumsaa/uuid package is marked as abandoned, to be replaced with ramsey/uuid.
