### PR TITLE
Enable support for StackPHP's middleware stack builder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,34 @@ It is also possible to change response header's name:
 ```php5
 $stack->enableResponseHeader('My-Custom-Request-Id');
 ```
+
+If you don't have access to the `RequestId` object instance (StackPHP, for example) the response header can be set via
+the fourth argument of the `RequestId` constructor method.
+
+```php5
+$generator = new UuidRequestIdGenerator(1337);
+$stack = new RequestId($kernel, $generator, 'X-Request-Id', 'My-Custom-Request-Id');
+```
+
+The third argument, for reference, is the name of the header:
+- That will be checked for a value before falling back to generating a new request ID,
+- Used to store the resulting request ID inside Symfony's request object.
+
+## StackPHP's Middleware Builder
+If you are already using [StackPHP](http://stackphp.com), just push the `RequestId` class into the builder.
+
+```php5
+$kernel = new AppKernel('dev', true);
+
+$generator = new UuidRequestIdGenerator(1337);
+$stack = (new Stack\Builder)
+    ->push('Qandidate\Stack\RequestId', $generator, 'X-Request-Id', 'X-Request-Id')
+    ->resolve($kernel);
+
+$kernel->loadClassCache();
+
+$request = Request::createFromGlobals();
+$response = $stack->handle($request);
+$response->send();
+$kernel->terminate($request, $response);
+```

--- a/src/Qandidate/Stack/RequestId.php
+++ b/src/Qandidate/Stack/RequestId.php
@@ -25,11 +25,16 @@ class RequestId implements HttpKernelInterface
     private $header;
     private $responseHeader;
 
-    public function __construct(HttpKernelInterface $app, RequestIdGenerator $generator, $header = 'X-Request-Id')
-    {
-        $this->app       = $app;
-        $this->generator = $generator;
-        $this->header    = $header;
+    public function __construct(
+        HttpKernelInterface $app,
+        RequestIdGenerator $generator,
+        $header = 'X-Request-Id',
+        $responseHeader = null
+    ) {
+        $this->app            = $app;
+        $this->generator      = $generator;
+        $this->header         = $header;
+        $this->responseHeader = $responseHeader;
     }
 
     /**

--- a/test/Qandidate/Stack/RequestIdTest.php
+++ b/test/Qandidate/Stack/RequestIdTest.php
@@ -102,6 +102,48 @@ class RequestIdTest extends TestCase
     /**
      * @test
      */
+    public function it_can_set_the_response_header_from_the_constructor_argument()
+    {
+        $this->requestIdGenerator->expects($this->any())
+            ->method('generate')
+            ->will($this->returnValue('yolo'));
+
+        $responseHeader = 'Request-Id';
+
+        $this->stackedApp->enableResponseHeader($responseHeader);
+        $normalResponse = $this->stackedApp->handle($this->createRequest());
+
+        $alternateStackedApp = new RequestId($this->app, $this->requestIdGenerator, $this->header, $responseHeader);
+        $alternateResponse = $alternateStackedApp->handle($this->createRequest());
+
+        $this->assertSame('yolo', $alternateResponse->headers->get($responseHeader));
+        $this->assertSame(
+            $normalResponse->headers->get($responseHeader),
+            $alternateResponse->headers->get($responseHeader)
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_override_the_response_header_argument_with_the_response_header_method()
+    {
+        $this->requestIdGenerator->expects($this->any())
+            ->method('generate')
+            ->will($this->returnValue('yolo'));
+
+        $alternateStackedApp = new RequestId($this->app, $this->requestIdGenerator, $this->header, 'Bad-Request-Id');
+        $alternateStackedApp->enableResponseHeader('Good-Request-Id');
+
+        $response = $alternateStackedApp->handle($this->CreateRequest());
+
+        $this->assertFalse($response->headers->has('Bad-Request-Id'));
+        $this->assertTrue($response->headers->has('Good-Request-Id'));
+    }
+
+    /**
+     * @test
+     */
     public function it_does_not_set_the_request_id_in_the_response_header_by_default()
     {
         $this->requestIdGenerator->expects($this->any())


### PR DESCRIPTION
There is currently no way of setting the response header when using this library with @StackPHP's [Builder](https://github.com/stackphp/builder) (though apart from that it already works perfectly).

These changes enable support for StackPHP without bringing in any backwards-compatibility issues, including test coverage and sections in the README for integrating with StackPHP.

Give this a tag and you can start pestering to be put on [their middlewares page](http://stackphp.com/middlewares) :+1: 
### Example Usage

``` php
$kernel = new AppKernel('dev', true);

$stack = (new Stack\Builder)
    ->push(
        'Qandidate\Stack\RequestId',
        new UuidRequestIdGenerator(1337),
        // Request header.
        'X-Request-Id',
        // Response header.
        'X-Request-Id'
    )
    // ... Loads of other middleware to be pushed to the stack.
    ->resolve($kernel);

$kernel->loadClassCache();

$request = Request::createFromGlobals();
$response = $stack->handle($request);
$response->send();
$kernel->terminate($request, $response);
```
