### PR TITLE
Usage of HttpKernelInterface::MAIN_REQUEST makes 5.3 the lowest compatible version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Middleware for adding request id to Symfony Request.",
     "license": "MIT",
     "require": {
-        "symfony/http-kernel": "^5.3",
+        "symfony/http-kernel": "^5.1.5",
         "symfony/http-foundation": "^5.0.7",
         "ramsey/uuid": "^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "description": "Middleware for adding request id to Symfony Request.",
     "license": "MIT",
     "require": {
-        "symfony/http-kernel": "^4.4.13||^5.1.5",
-        "symfony/http-foundation": "^4.4.7||^5.0.7",
+        "symfony/http-kernel": "^5.3",
+        "symfony/http-foundation": "^5.0.7",
         "ramsey/uuid": "^4.0"
     },
     "authors": [

--- a/src/Qandidate/Stack/RequestId.php
+++ b/src/Qandidate/Stack/RequestId.php
@@ -48,7 +48,7 @@ class RequestId implements HttpKernelInterface
     /**
      * {@inheritDoc}
      */
-    public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true)
+    public function handle(Request $request, int $type = HttpKernelInterface::MASTER_REQUEST, bool $catch = true)
     {
         if (!$request->headers->has($this->header)) {
             $request->headers->set($this->header, $this->generator->generate());


### PR DESCRIPTION
The added typehints also made <5.0 already non-compatible. 